### PR TITLE
Join saloon

### DIFF
--- a/index.php
+++ b/index.php
@@ -121,9 +121,9 @@ $app->post('/Demarer' , function($request, $response, $args){
  })
  ->setname("testCreateQuestions");
 
- $app->get('/Salon/{name}',function(){
+ $app->get('/Salon/{name}',function($request, $response, $args){
 	$acc = new StartController();
-	$acc->displaySaloon();
+	$acc->displaySaloon($args['name']);
  })->setName('Saloon');
 
 $app->get('/Rejoindre', function() {
@@ -131,6 +131,12 @@ $app->get('/Rejoindre', function() {
 	$acc = new JoinController();
 	$acc->displayJoin();
 })->setName('Rejoindre');
+
+$app->post('/Rejoindre' , function($request, $response, $args){
+	$acc = new JoinController();
+ 	$acc->testJoinSaloon() ;
+ })
+ ->setname("testCreateQuestions");
 
 $app->get('/De', function() {
 	$acc = new DiceController();

--- a/src/controllers/JoinController.php
+++ b/src/controllers/JoinController.php
@@ -3,15 +3,18 @@
 namespace trivial\controllers;
 
 use trivial\views\JoinView;
+use trivial\models as m;
 
 class JoinController {
 
 
 
 	public function displayJoin() {
-
+		$salonDispo =  m\Salon::all('nomSalon')->toArray();
 		$av = new JoinView();
-		echo $av->render();
+		   
+		
+		echo $av->render($salonDispo);
 	}
 
 }

--- a/src/controllers/JoinController.php
+++ b/src/controllers/JoinController.php
@@ -19,12 +19,24 @@ class JoinController {
 
 	public function testJoinSaloon(){
 		$nomSalon = $_POST['nomSalon'];
+		//Id du joueur permettra de modifier l'idSalon de ce joueur en base
+		$idJoueur = $_SESSION['idJoueur'];
 		
-		self::joinSaloon($nomSalon);
+		//récupère l'id du salon qui correspond au nom du salon.
+		$salon= m\Salon::where('nomSalon','=',$nomSalon);
+		$salon= $salon->first();
+		$idSalon = $salon->idSalon;
+		self::joinSaloon($nomSalon,$idSalon,$idJoueur);
 	}
 
-	public static function joinSaloon($nomSalon){
+	public static function joinSaloon($nomSalon,$idSalon,$idJoueur){
 	
+		$joueur =m\Joueur::find($idJoueur);
+		if($joueur){
+		$joueur->idSalon = $idSalon;
+		$joueur->save();
+		}
+		
 		global $app ;
 
         $url =  $app->getContainer()->get('router')->pathFor('Saloon',[

--- a/src/controllers/JoinController.php
+++ b/src/controllers/JoinController.php
@@ -17,4 +17,22 @@ class JoinController {
 		echo $av->render($salonDispo);
 	}
 
+	public function testJoinSaloon(){
+		$nomSalon = $_POST['nomSalon'];
+		
+		self::joinSaloon($nomSalon);
+	}
+
+	public static function joinSaloon($nomSalon){
+	
+		global $app ;
+
+        $url =  $app->getContainer()->get('router')->pathFor('Saloon',[
+			'name' => $nomSalon
+		]);
+  
+        header("Location: $url");
+        exit();
+	}
+
 }

--- a/src/controllers/StartController.php
+++ b/src/controllers/StartController.php
@@ -17,9 +17,9 @@ class StartController {
 		echo $av->render();
 	}
 
-	public function displaySaloon(){
+	public function displaySaloon($args){
 		$av = new SaloonView();
-		echo $av->render();
+		echo $av->render($args);
 	}
 
 

--- a/src/controllers/StartController.php
+++ b/src/controllers/StartController.php
@@ -20,7 +20,22 @@ class StartController {
 
 	public function displaySaloon($args){
 		$av = new SaloonView();
-		echo $av->render($args);
+		//Verifier si il y a d'autres joueurs dans le salon
+		//on récpère l'id du salon sur le quel la route nous mène.
+		$salon= m\Salon::where('nomSalon','=',$args);
+		$salon= $salon->first();
+		$idSalon = $salon->idSalon;
+		
+		//on récupère tous les joueurs qui ont l'idSalon que l'on vient de récupérer
+		$joueur = m\Joueur::where('idSalon','=',$idSalon)->get();
+		//On crée une liste pour y stocker le nom des Joueurs qui ont l'idSalon
+		$listeJoueur=array();
+		foreach($joueur as $nomJoueur){
+			$joueurSalon= $nomJoueur->pseudoJoueur;
+			array_push($listeJoueur,$joueurSalon);
+			
+		}
+		echo $av->render($args,$listeJoueur);
 	}
 
 

--- a/src/controllers/StartController.php
+++ b/src/controllers/StartController.php
@@ -5,6 +5,7 @@ namespace trivial\controllers;
 use trivial\views\StartView;
 use trivial\views\SaloonView;
 use trivial\models as m;
+use trivial\controllers\JoinController;
 
 
 class StartController {
@@ -28,6 +29,7 @@ class StartController {
 		$mode = $_POST['mode'] ;
 		$saloon = $_POST['salon'] ;
 		
+		
 		//mode devient un integer pour respecter la structure de la BDD
 		if($mode == "Privé"){
 			$mode = 1;
@@ -37,24 +39,27 @@ class StartController {
 		}
 		
 		self::createSaloon($mode,$saloon);
-		setcookie('salon', $saloon, time() + 365*24*3600, null, null, false, true);
-		global $app ;
-
-        $url =  $app->getContainer()->get('router')->pathFor('Saloon',[
-			'name' => $saloon
-		]);
-  
-        header("Location: $url");
-        exit();
+		
 	}
 
 	public static function createSaloon($mode,$saloon){
+		//Création du salon
 		$salon = new m\Salon();
 
 		$salon->nomSalon = $saloon;
 		$salon->visible = $mode;
 		
 		$salon->save();
+		// L'idSalon de la table Salon se synchronise avec l'idSalon de la table Joueur
+		$salon= m\Salon::where('nomSalon','=',$saloon);
+		$salon= $salon->first();
+		$idSalon = $salon->idSalon;
+		$idJoueur = $_SESSION['idJoueur'];
+		//La synchronisation se fait à travers la méthode joinSaloon.
+		//Ainsi un joueur qui crée un salon n'est ni plus ni moins qu'un
+		//joueur qui rejoint un salon, sauf que dans ce cas, le salon 
+		//vient d'être crée.
+		JoinController::joinSaloon($saloon,$idSalon,$idJoueur);
 	}
 
 }

--- a/src/views/JoinView.php
+++ b/src/views/JoinView.php
@@ -11,7 +11,83 @@ class JoinView {
         $ach = GlobalView::header();
 		$html ='';
         $html = $html.<<<END
-        <h1> Rejoindre Partie </h1>
+        <h4>Rejoindre une partie</h4>
+        <div class="screen">
+        Rejoindre le salon : 
+        <form action="" method="post">
+				 <p>
+				 <p> Nom du Salon à Rejoindre : </p> <input type="text" name="salonName" /> <input type="submit" value="Valider" />
+				 </p>
+			 </form>
+        </div>
+    
+        <style>
+        .screen{
+            display: flex;
+            flex-direction: column;
+           align-items: center;
+           width: 100%;
+            border : 2px solid rgb(95, 89, 89);
+    
+            padding-bottom: 15px;
+            padding-top: 15px;
+        }
+        body{
+            background: url(back.jpg);
+        }
+    
+        h4{
+            text-align : center;
+        }
+    
+        header{
+            text-align: center;
+            margin-top : 15%;
+            margin-bottom : 5px;
+        }
+        select{
+            color: #555;
+            padding: 8px 16px;
+            border: 1px solid transparent;
+            border-color: transparent transparent rgba(0, 0, 0, 0.1) transparent;
+            cursor: pointer;
+            user-select: none;
+            background : #f5f5f5;
+        }
+        .boutton{
+            padding:6px 0 6px 0;
+            font:bold 13px Arial;
+            background:#f5f5f5;
+            color:#555;
+            border-radius:2px;
+            width:150px;
+            border:1px solid #ccc;
+            box-shadow:1px 1px 3px #999;
+            text-align: center;
+            margin-bottom: 15px;
+            margin-top: 15px;
+        }
+    
+        a{
+            text-decoration: none;
+            color : black;
+        }
+    
+        .choice{
+            display: flex;
+            flex-direction: column;
+            padding:15px 0 0 0;
+            font:bold 13px Arial;
+    
+            border-radius:2px;
+        }
+        input{
+            margin-top: 10px;
+        }
+        </style>
+    
+    
+    
 
 
 

--- a/src/views/JoinView.php
+++ b/src/views/JoinView.php
@@ -6,8 +6,12 @@ use trivial\views\GlobalView;
 
 class JoinView {
 
-	public function render() {
-
+	public function render($salonDispo) {
+        $liste ='';
+        foreach($salonDispo as $value)
+        {
+    $liste .= '<option>'.$value['nomSalon'].'</option>';
+        }
         $ach = GlobalView::header();
 		$html ='';
         $html = $html.<<<END
@@ -15,8 +19,13 @@ class JoinView {
         <div class="screen">
         Rejoindre le salon : 
         <form action="" method="post">
-				 <p>
-				 <p> Nom du Salon à Rejoindre : </p> <input type="text" name="salonName" /> <input type="submit" value="Valider" />
+        <div class = "choice">
+        <select name="nomSalon">
+        $liste
+        </select>
+        </div>
+        <p>
+				  <input type="submit" value="Valider" />
 				 </p>
 			 </form>
         </div>

--- a/src/views/SaloonView.php
+++ b/src/views/SaloonView.php
@@ -8,14 +8,15 @@ use trivial\views\GlobalView;
 use trivial\controllers as c;
 
 class SaloonView{
-    public function render() {
-
+    public function render($args) {
+		
         $ach = GlobalView::header();
-        $pseudo =    $_SESSION['pseudoJoueur'];
-        $cookie = $_COOKIE['salon'];
+		$pseudo =    $_SESSION['pseudoJoueur'];
+	
+       
 		$html ='';
         $html = $html.<<<END
-        <h4>Salon: $cookie</h4>
+        <h4>Salon: $args</h4>
 
 	<div class="screen">
     Joueur dans le salon

--- a/src/views/SaloonView.php
+++ b/src/views/SaloonView.php
@@ -8,11 +8,15 @@ use trivial\views\GlobalView;
 use trivial\controllers as c;
 
 class SaloonView{
-    public function render($args) {
+    public function render($args,$listeJoueur) {
 		
         $ach = GlobalView::header();
-		$pseudo =    $_SESSION['pseudoJoueur'];
-	
+		$pseudo='';
+		//Pseudo affiche la liste de tous les joueurs présents dans le salon.
+		foreach($listeJoueur as $value){
+		$pseudo.= $value."</BR>";
+		}
+		
        
 		$html ='';
         $html = $html.<<<END


### PR DESCRIPTION
Cette fonctionnalité permet de lier un joueur à un salon.
Quand un joueur rejoint un salon existant, son idSalon devient le même que celui du salon.
Ainsi le joueur appartient au salon dans lequel il se situe.
Il en est de même pour le joueur qui crée son salon : Il appartient à ce salon.

Cela se passe donc côté BDD, et cela permet visuellement d'avoir notamment tous les joueurs présents
dans un même salon.